### PR TITLE
JSONify key/keys params

### DIFF
--- a/couchbase-view-helpers.gemspec
+++ b/couchbase-view-helpers.gemspec
@@ -25,6 +25,8 @@ Gem::Specification.new do |spec|
     spec.add_dependency 'couchbase', '>= 1.3.3'
   end
 
+  spec.add_dependency 'multi_json'
+
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'
 end

--- a/lib/couchbase/view_helpers.rb
+++ b/lib/couchbase/view_helpers.rb
@@ -1,4 +1,5 @@
 require 'couchbase/view_helpers/version'
+require 'multi_json'
 
 module Couchbase
 
@@ -94,15 +95,10 @@ module Couchbase
 
     def jsonify_key(key)
       if key.is_a? Array
-        key.to_s
+        key.to_s # Array#to_s provides jsonification
       else
-        quote_key(key)
+        MultiJson.dump(key)
       end
-    end
-
-    def quote_key(key)
-      key = key.to_s
-      key =~ /^"/ ? key : '"' + key + '"'
     end
 
   end

--- a/test/test_view_helpers.rb
+++ b/test/test_view_helpers.rb
@@ -8,17 +8,22 @@ class TestViewHelpers < MiniTest::Unit::TestCase
 
   def test_can_set_key
     assert_instance_of MockView, @view.key('foo')
-    assert_equal 'foo', @view.params[:key]
+    assert_equal "\"foo\"", @view.params[:key]
   end
 
   def test_can_set_keys
     assert_instance_of MockView, @view.keys(['foo', 'bar'])
-    assert_equal ['foo', 'bar'], @view.params[:keys]
+    assert_equal ["\"foo\"", "\"bar\""], @view.params[:keys]
+  end
+
+  def test_can_set_integer_key
+    assert_instance_of MockView, @view.key(1234)
+    assert_equal '1234', @view.params[:key]
   end
 
   def test_can_set_keys_with_args
     assert_instance_of MockView, @view.keys('foo', 'bar')
-    assert_equal ['foo', 'bar'], @view.params[:keys]
+    assert_equal ["\"foo\"", "\"bar\""], @view.params[:keys]
   end
 
   def test_can_paginate


### PR DESCRIPTION
# JSONify key/keys params 

According to [couchbase specifications](http://docs.couchbase.com/admin/admin/Views/views-querying.html), `key` or `keys`, or other params values in the view query interface need to be jsonified. This includes both string and integer keys, which are jsonified differently. This PR attempts to follow that specification closely. 
## What is involved
1. use `multi_json` to jsonify all the key values. 
2. add a test to cover integer key scenario.
